### PR TITLE
Make it compatible with the latest evernote (yinxiang) API.

### DIFF
--- a/lib/enml2html-helper.js
+++ b/lib/enml2html-helper.js
@@ -18,5 +18,5 @@ function bodyHashToString(bodyHash) {
 }
 
 function genResourceUrl(webApiUrlPrefix, noteGuid, noteKey, resourceGuid, filename) {
-  return `${webApiUrlPrefix}/sh/${noteGuid}/${noteKey}/res/${resourceGuid}/${filename}`;
+  return `${webApiUrlPrefix}/res/${resourceGuid}`;
 }


### PR DESCRIPTION
The link for img in resource file doesn't work anymore. Referring to the latest API document, the link should be assembled in another way. 
See it here:
https://dev.evernote.com/doc/articles/resources.php#downloading
With this change, then the html output can show the images very well.