### PR TITLE
Improve the logic of removing the enml head.

### DIFF
--- a/lib/enml2html.js
+++ b/lib/enml2html.js
@@ -6,8 +6,7 @@ const bodyHashToString = enml2htmlHelper.bodyHashToString;
 const genResourceUrl = enml2htmlHelper.genResourceUrl;
 
 module.exports = function enml2html(enml, resources, webApiUrlPrefix, noteKey) {
-  let start = enml.indexOf('enml2.dtd">') + 11;
-  enml = enml.slice(start); // rm <?xml version="1.0"...enml2.dtd">\n
+  enml = enml.replace(/^.*enml2.dtd.>/, '');
   let $ = cheerio.load(enml);
 
   $('en-note').each(function () {


### PR DESCRIPTION
Sometimes, enml2.dtd ends with single quotes, rather than double quotes. This may lead to parsing problem in original code.