### PR TITLE
Fix Evernote bodyHash format change

### DIFF
--- a/lib/enml2html-helper.js
+++ b/lib/enml2html-helper.js
@@ -7,8 +7,8 @@ module.exports = {
 
 function bodyHashToString(bodyHash) {
   let str = '';
-  for (let i in bodyHash) {
-    let hexStr = bodyHash[i].toString(16);
+  for (let i in bodyHash.data) {
+    let hexStr = bodyHash.data[i].toString(16);
     if (hexStr.length === 1) {
       hexStr = '0' + hexStr;
     }


### PR DESCRIPTION
Fixes #3. 

Due to `bodyHash` structure now looking like:
```
[
  {
    "guid": "9f73e25d-fa8b-4dab-9bbf-df5359bebe45",
    "noteGuid": "b0f44843-46de-418b-878c-e4e9629a430c",
    "data": {
      "bodyHash": {
        "type": "Buffer",
        "data": [5,65,137,143,214,252,185,77,233,211,22,168,94,55,35,225]
      }
      ...
```