### PR TITLE
Some text content is lost

### DIFF
--- a/lib/enml2html.js
+++ b/lib/enml2html.js
@@ -48,7 +48,7 @@ module.exports = function enml2html (note, cleanMode = false) {
                hash="${Buffer.from(resource.data.bodyHash).toString('hex')}" \
                alt="${resource.attributes.fileName || ''}" \
                ${genStyle(self, ['style', 'title', 'lang', 'xml:lang', 'dir', 'width', 'height'])}
-          />
+          />${self.html()}</img>
         `)
         break
       case 'audio/wav':


### PR DESCRIPTION
Because it's inserted as <en-media> tag's body. See below example:
```
<en-media longdesc="./1537495522238.png" alt="Alt text" title="" type="image/png" hash="9bdc1f04961d7f5770a2a1dedc91ebb9"> <br>Softmax分类器。。。</en-media>
```
Softmax stuff is part of the note content, but it's ignored by enml2html. I guess this might have been the new change in enml? My patch tries to add the content back.
