### PR TITLE
Don't remove \n while translating enml to html.

### DIFF
--- a/lib/enml2html.js
+++ b/lib/enml2html.js
@@ -92,7 +92,6 @@ module.exports = function enml2html (note, cleanMode = false) {
   }
   // remove \n \s
   return $.html()
-    .replace(/\s*\n+\s*/g, '')
     .trim()
 }
 

--- a/lib/enml2html.js
+++ b/lib/enml2html.js
@@ -92,6 +92,7 @@ module.exports = function enml2html (note, cleanMode = false) {
   }
   // remove \n \s
   return $.html()
+    .replace(/\s*\n+\s*/g, '\n')
     .trim()
 }
 

--- a/lib/enml2html.js
+++ b/lib/enml2html.js
@@ -11,9 +11,9 @@ module.exports = function enml2html (note, cleanMode = false) {
   assert(webApiUrlPrefix, 'webApiUrlPrefix should exist!')
   assert(noteKey, 'noteKey should exist!')
 
-  enml = enml.replace('<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">', '')
+  enml = enml.replace(/.*enml2.dtd.>.*<div/, '<div');
+  let $ = cheerio.load(enml);
 
-  let $ = cheerio.load(enml)
   $('en-note').each(function () {
     let self = $(this)
     self.css('background-color', self.attr('bgcolor'))


### PR DESCRIPTION
MAC上的markdown版evernote有这个问题。
如果把“\n”都删掉，代码块就没换行了。